### PR TITLE
Adding Alpine base image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,17 +10,17 @@ before_script:
   - docker build -t nimlang/nim:0.11.2-slim 0.11.2/slim
   - docker build -t nimlang/nim:0.12.0-alpine 0.12.0/alpine
   - docker build -t nimlang/nim:0.12.0-slim 0.12.0/slim
-  - docker build -t nimlang/nim:0.13.0-alpine 0.13.0/alpine
   - docker build -t nimlang/nim:0.13.0-alpine-slim 0.13.0/alpine/slim
+  - docker build -t nimlang/nim:0.13.0-alpine 0.13.0/alpine
   - docker build -t nimlang/nim:0.13.0-slim 0.13.0/slim
-  - docker build -t nimlang/nim:0.14.0-alpine 0.14.0/alpine
   - docker build -t nimlang/nim:0.14.0-alpine-slim 0.14.0/alpine/slim
+  - docker build -t nimlang/nim:0.14.0-alpine 0.14.0/alpine
   - docker build -t nimlang/nim:0.14.0-slim 0.14.0/slim
-  - docker build -t nimlang/nim:0.14.2-alpine 0.14.2/alpine
   - docker build -t nimlang/nim:0.14.2-alpine-slim 0.14.2/alpine/slim
+  - docker build -t nimlang/nim:0.14.2-alpine 0.14.2/alpine
   - docker build -t nimlang/nim:0.14.2-slim 0.14.2/slim
-  - docker build -t nimlang/nim:0.14.3-alpine 0.14.3/alpine
   - docker build -t nimlang/nim:0.14.3-alpine-slim 0.14.3/alpine/slim
+  - docker build -t nimlang/nim:0.14.3-alpine 0.14.3/alpine
   - docker build -t nimlang/nim:0.14.3-slim 0.14.3/slim
   - docker build -t nimlang/nim:0.13.0 0.13.0
   - docker build -t nimlang/nim:0.14.0 0.14.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,38 +4,68 @@ services:
   - docker
 
 before_script:
+  - docker build -t nimlang/nim:0.11.0-alpine 0.11.0/alpine
   - docker build -t nimlang/nim:0.11.0-slim 0.11.0/slim
+  - docker build -t nimlang/nim:0.11.2-alpine 0.11.2/alpine
   - docker build -t nimlang/nim:0.11.2-slim 0.11.2/slim
+  - docker build -t nimlang/nim:0.12.0-alpine 0.12.0/alpine
   - docker build -t nimlang/nim:0.12.0-slim 0.12.0/slim
+  - docker build -t nimlang/nim:0.13.0-alpine 0.13.0/alpine
+  - docker build -t nimlang/nim:0.13.0-alpine-slim 0.13.0/alpine/slim
   - docker build -t nimlang/nim:0.13.0-slim 0.13.0/slim
+  - docker build -t nimlang/nim:0.14.0-alpine 0.14.0/alpine
+  - docker build -t nimlang/nim:0.14.0-alpine-slim 0.14.0/alpine/slim
   - docker build -t nimlang/nim:0.14.0-slim 0.14.0/slim
+  - docker build -t nimlang/nim:0.14.2-alpine 0.14.2/alpine
+  - docker build -t nimlang/nim:0.14.2-alpine-slim 0.14.2/alpine/slim
   - docker build -t nimlang/nim:0.14.2-slim 0.14.2/slim
+  - docker build -t nimlang/nim:0.14.3-alpine 0.14.3/alpine
+  - docker build -t nimlang/nim:0.14.3-alpine-slim 0.14.3/alpine/slim
   - docker build -t nimlang/nim:0.14.3-slim 0.14.3/slim
   - docker build -t nimlang/nim:0.13.0 0.13.0
   - docker build -t nimlang/nim:0.14.0 0.14.0
   - docker build -t nimlang/nim:0.14.2 -t nimlang/nim:latest 0.14.2
   - docker build -t nimlang/nim:0.14.3 -t nimlang/nim:devel 0.14.3
   - docker build -t nimlang/nim:0.13.0-onbuild 0.13.0/onbuild
+  - docker build -t nimlang/nim:0.13.0-alpine-onbuild 0.13.0/alpine/onbuild
   - docker build -t nimlang/nim:0.14.0-onbuild 0.14.0/onbuild
+  - docker build -t nimlang/nim:0.14.0-alpine-onbuild 0.14.0/alpine/onbuild
   - docker build -t nimlang/nim:0.14.2-onbuild 0.14.2/onbuild
+  - docker build -t nimlang/nim:0.14.2-alpine-onbuild 0.14.2/alpine/onbuild
   - docker build -t nimlang/nim:0.14.3-onbuild 0.14.3/onbuild
+  - docker build -t nimlang/nim:0.14.3-alpine-onbuild 0.14.3/alpine/onbuild
 
 script:
   - docker login -e="$DOCKER_EMAIL" -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
   - docker push nimlang/nim:0.11.0-slim
+  - docker push nimlang/nim:0.11.0-alpine
   - docker push nimlang/nim:0.11.2-slim
+  - docker push nimlang/nim:0.11.2-alpine
   - docker push nimlang/nim:0.12.0-slim
+  - docker push nimlang/nim:0.12.0-alpine
   - docker push nimlang/nim:0.13.0-slim
+  - docker push nimlang/nim:0.13.0-alpine-slim
   - docker push nimlang/nim:0.14.0-slim
+  - docker push nimlang/nim:0.14.0-alpine-slim
   - docker push nimlang/nim:0.14.2-slim
+  - docker push nimlang/nim:0.14.2-alpine-slim
   - docker push nimlang/nim:0.14.3-slim
+  - docker push nimlang/nim:0.14.3-alpine-slim
   - docker push nimlang/nim:0.13.0
   - docker push nimlang/nim:0.14.0
   - docker push nimlang/nim:0.14.2
   - docker push nimlang/nim:0.14.3
+  - docker push nimlang/nim:0.13.0-alpine
+  - docker push nimlang/nim:0.14.0-alpine
+  - docker push nimlang/nim:0.14.2-alpine
+  - docker push nimlang/nim:0.14.3-alpine
   - docker push nimlang/nim:latest
   - docker push nimlang/nim:devel
   - docker push nimlang/nim:0.13.0-onbuild
   - docker push nimlang/nim:0.14.0-onbuild
   - docker push nimlang/nim:0.14.2-onbuild
   - docker push nimlang/nim:0.14.3-onbuild
+  - docker push nimlang/nim:0.13.0-alpine-onbuild
+  - docker push nimlang/nim:0.14.0-alpine-onbuild
+  - docker push nimlang/nim:0.14.2-alpine-onbuild
+  - docker push nimlang/nim:0.14.3-alpine-onbuild

--- a/0.11.0/alpine/Dockerfile
+++ b/0.11.0/alpine/Dockerfile
@@ -1,0 +1,8 @@
+FROM alpine 
+MAINTAINER Guilherme Thomazi Bonicontro <thomazi@linux.com>
+
+RUN apk add --no-cache g++ curl tar xz
+RUN mkdir -p /nim;\
+    curl -sL "http://nim-lang.org/download/nim-0.11.0.tar.xz" | tar xJ --strip-components=1 -C /nim;\
+    cd /nim; sh build.sh;\
+    ln -s `pwd`/bin/nim /bin/nim

--- a/0.11.2/alpine/Dockerfile
+++ b/0.11.2/alpine/Dockerfile
@@ -1,0 +1,8 @@
+FROM alpine 
+MAINTAINER Guilherme Thomazi Bonicontro <thomazi@linux.com>
+
+RUN apk add --no-cache g++ curl tar xz
+RUN mkdir -p /nim;\
+    curl -sL "http://nim-lang.org/download/nim-0.11.2.tar.xz" | tar xJ --strip-components=1 -C /nim;\
+    cd /nim; sh build.sh;\
+    ln -s `pwd`/bin/nim /bin/nim

--- a/0.12.0/alpine/Dockerfile
+++ b/0.12.0/alpine/Dockerfile
@@ -1,0 +1,8 @@
+FROM alpine 
+MAINTAINER Guilherme Thomazi Bonicontro <thomazi@linux.com>
+
+RUN apk add --no-cache g++ curl tar xz
+RUN mkdir -p /nim;\
+    curl -sL "http://nim-lang.org/download/nim-0.12.0.tar.xz" | tar xJ --strip-components=1 -C /nim;\
+    cd /nim; sh build.sh;\
+    ln -s `pwd`/bin/nim /bin/nim

--- a/0.13.0/alpine/Dockerfile
+++ b/0.13.0/alpine/Dockerfile
@@ -1,0 +1,6 @@
+FROM nimlang/nim:0.13.0-alpine-slim
+MAINTAINER Guilherme Thomazi Bonicontro <thomazi@linux.com>
+
+RUN git clone https://github.com/nim-lang/nimble.git;\
+    cd nimble; nim -d:release c -r src/nimble -y install;\
+    ln -s `pwd`/nimble /bin/nimble

--- a/0.13.0/alpine/onbuild/Dockerfile
+++ b/0.13.0/alpine/onbuild/Dockerfile
@@ -1,0 +1,7 @@
+FROM nimlang/nim:0.13.0-alpine
+
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+ONBUILD COPY . /usr/src/app
+ONBUILD RUN nimble build

--- a/0.13.0/alpine/slim/Dockerfile
+++ b/0.13.0/alpine/slim/Dockerfile
@@ -1,0 +1,8 @@
+FROM alpine 
+MAINTAINER Guilherme Thomazi Bonicontro <thomazi@linux.com>
+
+RUN apk add --no-cache g++ curl tar xz
+RUN mkdir -p /nim;\
+    curl -sL "http://nim-lang.org/download/nim-0.13.0.tar.xz" | tar xJ --strip-components=1 -C /nim;\
+    cd /nim; sh build.sh;\
+    ln -s `pwd`/bin/nim /bin/nim

--- a/0.14.0/alpine/Dockerfile
+++ b/0.14.0/alpine/Dockerfile
@@ -1,0 +1,6 @@
+FROM nimlang/nim:0.14.0-alpine-slim
+MAINTAINER Guilherme Thomazi Bonicontro <thomazi@linux.com>
+
+RUN git clone https://github.com/nim-lang/nimble.git;\
+    cd nimble; nim -d:release c -r src/nimble -y install;\
+    ln -s `pwd`/nimble /bin/nimble

--- a/0.14.0/alpine/onbuild/Dockerfile
+++ b/0.14.0/alpine/onbuild/Dockerfile
@@ -1,0 +1,7 @@
+FROM nimlang/nim:0.14.0-alpine
+
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+ONBUILD COPY . /usr/src/app
+ONBUILD RUN nimble build

--- a/0.14.0/alpine/slim/Dockerfile
+++ b/0.14.0/alpine/slim/Dockerfile
@@ -1,0 +1,8 @@
+FROM alpine 
+MAINTAINER Guilherme Thomazi Bonicontro <thomazi@linux.com>
+
+RUN apk add --no-cache g++ curl tar xz
+RUN mkdir -p /nim;\
+    curl -sL "http://nim-lang.org/download/nim-0.14.0.tar.xz" | tar xJ --strip-components=1 -C /nim;\
+    cd /nim; sh build.sh;\
+    ln -s `pwd`/bin/nim /bin/nim

--- a/0.14.2/alpine/Dockerfile
+++ b/0.14.2/alpine/Dockerfile
@@ -1,0 +1,6 @@
+FROM nimlang/nim:0.14.2-alpine-slim
+MAINTAINER Guilherme Thomazi Bonicontro <thomazi@linux.com>
+
+RUN git clone https://github.com/nim-lang/nimble.git;\
+    cd nimble; nim -d:release c -r src/nimble -y install;\
+    ln -s `pwd`/nimble /bin/nimble

--- a/0.14.2/alpine/onbuild/Dockerfile
+++ b/0.14.2/alpine/onbuild/Dockerfile
@@ -1,0 +1,7 @@
+FROM nimlang/nim:0.14.2-alpine
+
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+ONBUILD COPY . /usr/src/app
+ONBUILD RUN nimble build

--- a/0.14.2/alpine/slim/Dockerfile
+++ b/0.14.2/alpine/slim/Dockerfile
@@ -1,0 +1,8 @@
+FROM alpine 
+MAINTAINER Guilherme Thomazi Bonicontro <thomazi@linux.com>
+
+RUN apk add --no-cache g++ curl tar xz
+RUN mkdir -p /nim;\
+    curl -sL "http://nim-lang.org/download/nim-0.14.2.tar.xz" | tar xJ --strip-components=1 -C /nim;\
+    cd /nim; sh build.sh;\
+    ln -s `pwd`/bin/nim /bin/nim

--- a/0.14.3/alpine/Dockerfile
+++ b/0.14.3/alpine/Dockerfile
@@ -3,4 +3,4 @@ MAINTAINER Guilherme Thomazi Bonicontro <thomazi@linux.com>
 
 RUN git clone https://github.com/nim-lang/nimble.git;\
     cd nimble; nim -d:release c -r src/nimble -y install;\
-    ln -s `pwd`/nimble/nimble /bin/nimble
+    ln -s `pwd`/nimble /bin/nimble

--- a/0.14.3/alpine/Dockerfile
+++ b/0.14.3/alpine/Dockerfile
@@ -1,9 +1,6 @@
-FROM alpine:latest
-MAINTAINER guitmz <thomazi@linux.com>
+FROM nimlang/nim:0.14.3-alpine-slim
+MAINTAINER Guilherme Thomazi Bonicontro <thomazi@linux.com>
 
-RUN apk add --no-cache g++ git
-RUN git clone git://github.com/nim-lang/Nim.git nim;\
-    cd nim; git clone --depth 1 git://github.com/nim-lang/csources;\
-    cd csources; sh build.sh; chmod +x ../bin/nim;\
-    cd /nim; bin/nim c koch; ./koch boot -d:release;\
-    ln -s `pwd`/bin/nim /bin/nim
+RUN git clone https://github.com/nim-lang/nimble.git;\
+    cd nimble; nim -d:release c -r src/nimble -y install;\
+    ln -s `pwd`/nimble/nimble /bin/nimble

--- a/0.14.3/alpine/Dockerfile
+++ b/0.14.3/alpine/Dockerfile
@@ -1,0 +1,9 @@
+FROM alpine:latest
+MAINTAINER guitmz <thomazi@linux.com>
+
+RUN apk add --no-cache g++ git
+RUN git clone git://github.com/nim-lang/Nim.git nim;\
+    cd nim; git clone --depth 1 git://github.com/nim-lang/csources;\
+    cd csources; sh build.sh; chmod +x ../bin/nim;\
+    cd /nim; bin/nim c koch; ./koch boot -d:release;\
+    ln -s `pwd`/bin/nim /bin/nim

--- a/0.14.3/alpine/onbuild/Dockerfile
+++ b/0.14.3/alpine/onbuild/Dockerfile
@@ -1,0 +1,7 @@
+FROM nimlang/nim:0.14.3-alpine
+
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+ONBUILD COPY . /usr/src/app
+ONBUILD RUN nimble build

--- a/0.14.3/alpine/slim/Dockerfile
+++ b/0.14.3/alpine/slim/Dockerfile
@@ -1,0 +1,9 @@
+FROM alpine
+MAINTAINER Guilherme Thomazi Bonicontro <thomazi@linux.com>
+
+RUN apk add --no-cache g++ git
+RUN git clone git://github.com/nim-lang/Nim.git nim;\
+    cd nim; git clone --depth 1 git://github.com/nim-lang/csources;\
+    cd csources; sh build.sh; chmod +x ../bin/nim;\
+    cd /nim; bin/nim c koch; ./koch boot -d:release;\
+    ln -s `pwd`/bin/nim /bin/nim

--- a/0.14.3/slim/Dockerfile
+++ b/0.14.3/slim/Dockerfile
@@ -6,4 +6,3 @@ RUN git clone git://github.com/nim-lang/Nim.git nim;\
     cd csources; sh build.sh;\
     bin/nim c koch; ./koch boot -d:release;\
     ln -s `pwd`/bin/nim /bin/nim
-

--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ Images come in three flavors: *regular*, *slim*, and *onbuild*. Regular images i
 | Tag                    | Dockerfile                                                                                      |
 | ---------------------- | ----------------------------------------------------------------------------------------------- |
 | `0.14.3-alpine`          | [0.14.3/alpine/Dockerfile](https://github.com/moigagoo/nimage/blob/master/0.14.3/alpine/Dockerfile) |
+| `0.12.0-alpine`          | [0.12.0/alpine/Dockerfile](https://github.com/moigagoo/nimage/blob/master/0.12.0/alpine/Dockerfile) |
+| `0.11.2-alpine`          | [0.11.2/alpine/Dockerfile](https://github.com/moigagoo/nimage/blob/master/0.11.2/alpine/Dockerfile) |
+| `0.11.0-alpine`          | [0.11.0/alpine/Dockerfile](https://github.com/moigagoo/nimage/blob/master/0.11.0/alpine/Dockerfile) |
 
 
 ## Onbuild

--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ Images come in three flavors: *regular*, *slim*, and *onbuild*. Regular images i
 | `0.11.2-slim`          | [0.11.2/slim/Dockerfile](https://github.com/moigagoo/nimage/blob/master/0.11.2/slim/Dockerfile) |
 | `0.11.0-slim`          | [0.11.0/slim/Dockerfile](https://github.com/moigagoo/nimage/blob/master/0.11.0/slim/Dockerfile) |
 
+## Alpine
+| Tag                    | Dockerfile                                                                                      |
+| ---------------------- | ----------------------------------------------------------------------------------------------- |
+| `0.14.3-alpine`          | [0.14.3/alpine/Dockerfile](https://github.com/moigagoo/nimage/blob/master/0.14.3/alpine/Dockerfile) |
+
+
 ## Onbuild
 
 | Tag                    | Dockerfile                                                                                            |
@@ -68,6 +74,12 @@ $ docker pull nimlang/nim:devel
 
 ```shell
 $ docker run -it --rm --name my-running-app -v `pwd`:/usr/src/myapp -w /usr/src/myapp nimlang/nim nim c -r your-nim-file.nim
+```
+
+## Compiling a **Static** Single File
+
+```shell
+$ docker run -it --rm --name my-running-app -v `pwd`:/usr/src/myapp -w /usr/src/myapp nimlang/nim:0.14.3-alpine nim c --passL:-static your-nim-file.nim
 ```
 
 ## Building a Nimble Package


### PR DESCRIPTION
This PR adds an Alpine based image. It's slimmer and allows static binaries to be built. Should close #2  and #3.

We could probably use this as base for all `-slim` images, the big problem is building binaries with `musl` and trying to run outside where `glibc` is the default.