### PR TITLE
Slimmer choosenim image

### DIFF
--- a/choosenim/Dockerfile
+++ b/choosenim/Dockerfile
@@ -1,6 +1,6 @@
 FROM bitnami/minideb
 
-RUN apt-get update && apt-get install -y curl xz-utils gcc openssl ca-certificates
+RUN apt-get update && apt-get install -y curl xz-utils gcc openssl ca-certificates git
 
 WORKDIR /root/
 RUN curl https://nim-lang.org/choosenim/init.sh -sSf | bash -s -- -y

--- a/choosenim/Dockerfile
+++ b/choosenim/Dockerfile
@@ -1,17 +1,12 @@
-FROM ubuntu:devel
+FROM bitnami/minideb
 
-RUN apt-get update && apt-get install -y curl xz-utils g++ git make
-ENV OPENSSLDIR=/usr/local/ssl
-
-# Build OpenSSL 1 from source
-RUN mkdir -p $OPENSSLDIR/src
-WORKDIR $OPENSSLDIR/src
-RUN git clone https://github.com/openssl/openssl.git --depth 1 -b OpenSSL_1_1_1-stable .
-RUN ./config --prefix=$OPENSSLDIR --openssldir=$OPENSSLDIR && make && make install
-RUN ls $OPENSSLDIR/*
-RUN echo "$OPENSSLDIR/lib" > /etc/ld.so.conf.d/openssl.conf
-RUN ldconfig
+RUN apt update
+RUN install_packages openssl curl xz-utils ca-certificates gcc
 
 WORKDIR /root/
 RUN curl https://nim-lang.org/choosenim/init.sh -sSf | bash -s -- -y
 ENV PATH=/root/.nimble/bin:$PATH
+
+RUN apt -y autoclean
+RUN apt -y clean
+RUN rm -r /tmp/*

--- a/choosenim/Dockerfile
+++ b/choosenim/Dockerfile
@@ -1,12 +1,12 @@
 FROM bitnami/minideb
 
-RUN apt update
-RUN install_packages openssl curl xz-utils ca-certificates gcc
+RUN apt-get update && apt-get install -y curl xz-utils gcc openssl ca-certificates
 
 WORKDIR /root/
 RUN curl https://nim-lang.org/choosenim/init.sh -sSf | bash -s -- -y
 ENV PATH=/root/.nimble/bin:$PATH
 
+RUN apt -y autoremove
 RUN apt -y autoclean
 RUN apt -y clean
 RUN rm -r /tmp/*


### PR DESCRIPTION
Tries to slim down the choosenim image and simplify it via the following:
- Change base image to bitnami/minideb (which ideally is also more reliable than the ubuntu devel base)
- Remove openssl self compilation (which also gets rid of make and git dependency) and just download the openssl package
- clean out /tmp dir, do autoremove/autoclean/clean in the hopes that it removes anything superfluous

I ran the image with the addition of these 2 lines to test if compilation inside of it can be done:
```dockerfile
COPY ./mynimfile.nim .
RUN nim c mynimfile.nim
```
That ran without issue:

```txt
Step 10/11 : COPY ./build.nim .
 ---> eec06303c7f0
Step 11/11 : RUN nim c ./build.nim
 ---> Running in cd93f2ff69c5
Hint: used config file '/root/.choosenim/toolchains/nim-1.6.10/config/nim.cfg' [Conf]
Hint: used config file '/root/.choosenim/toolchains/nim-1.6.10/config/config.nims' [Conf]
.........................................................
/root/build.nim(4, 5) Hint: 'z' is declared but not used [XDeclaredButNotUsed]
CC: .choosenim/toolchains/nim-1.6.10/lib/std/private/digitsutils.nim
CC: .choosenim/toolchains/nim-1.6.10/lib/system/dollars.nim
CC: .choosenim/toolchains/nim-1.6.10/lib/system.nim
CC: build.nim
Hint:  [Link]
Hint: gc: refc; opt: none (DEBUG BUILD, `-d:release` generates faster code)
26645 lines; 0.393s; 31.68MiB peakmem; proj: /root/build.nim; out: /root/build [SuccessX]
Removing intermediate container cd93f2ff69c5
 ---> 35a33f4ddf4f
Successfully built 35a33f4ddf4f
Successfully tagged choosenim-slim:latest
```

Overall this reduced (locally) the size of the image from 885M to 538M.
I think a huge amount of that is because this is basically a nim build that includes a gcc compiler, which is massive, and openssl and ca-certificates aren'tt exactly tiny either.
Not sure what else I could be doing to slim this down any, other than alpine but I think for a container intended for compiling software in, alpine isn't a good solution. I'd want those kinds of containers to be focused on reliability and debian with glibc is just **way** more widespread in useage and thus reliable.