### PR TITLE
Make `choosenim` image smaller

### DIFF
--- a/choosenim/Dockerfile
+++ b/choosenim/Dockerfile
@@ -1,12 +1,11 @@
 FROM bitnami/minideb
 
-RUN apt-get update && apt-get install -y curl xz-utils gcc openssl ca-certificates git
-
 WORKDIR /root/
-RUN curl https://nim-lang.org/choosenim/init.sh -sSf | bash -s -- -y
-ENV PATH=/root/.nimble/bin:$PATH
 
-RUN apt -y autoremove
-RUN apt -y autoclean
-RUN apt -y clean
-RUN rm -r /tmp/*
+RUN apt-get update && \
+  apt-get install -y curl xz-utils gcc openssl ca-certificates git && \
+  curl https://nim-lang.org/choosenim/init.sh -sSf | bash -s -- -y && \
+  apt -y autoremove && \
+  apt -y clean && \
+  rm -r /tmp/*
+ENV PATH=/root/.nimble/bin:$PATH


### PR DESCRIPTION
`RUN` creates a new layer and so even if we remove the files later they will still stay in the image

This runs all the commands in a single step so that layer generated doesn't have any unneeded APT artefacts.

Results after this PR (We slim the image by 80MB)
```
REPOSITORY                 TAG       IMAGE ID       CREATED          SIZE
new-choosenim              latest    6ee80a63716e   45 seconds ago   548MB
old-choosenim              latest    56a5313d887a   35 minutes ago   628MB
```